### PR TITLE
chore: rename to power-flow-card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Power Distribution Card
+# Power Flow Card
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=flat-square)](https://github.com/hacs/integration)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/ulic75/power-distribution-card?style=flat-square)
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ulic75/power-distribution-card/CI?style=flat-square)
-![GitHub all releases](https://img.shields.io/github/downloads/ulic75/power-distribution-card/total?style=flat-square)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/ulic75/power-flow-card?style=flat-square)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/ulic75/power-flow-card/CI?style=flat-square)
+![GitHub all releases](https://img.shields.io/github/downloads/ulic75/power-flow-card/total?style=flat-square)
 
 This card for [Home Assistant](https://github.com/home-assistant/home-assistant) Dashboards is designed to provide power distribution in an identical style to the Official Energy Distribution card included by Home Assistant.
 
@@ -18,17 +18,17 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 
 ### Manual install
 
-1. Download and copy `power-distribution-card.js` from the [latest release](https://github.com/ulic75/power-distribution-card/releases/latest) into your `config/www` directory.
+1. Download and copy `power-flow-card.js` from the [latest release](https://github.com/ulic75/power-flow-card/releases/latest) into your `config/www` directory.
 
 2. Add the resource reference as decribed below.
 
 ### Add resource reference
 
-If you configure Dashboards via YAML, add a reference to `power-distribution-card.js` inside your `configuration.yaml`:
+If you configure Dashboards via YAML, add a reference to `power-flow-card.js` inside your `configuration.yaml`:
 
 ```yaml
 resources:
-  - url: /local/power-distribution-card.js
+  - url: /local/power-flow-card.js
     type: module
 ```
 
@@ -36,8 +36,8 @@ Else, if you prefer the graphical editor, use the menu to add the resource:
 
 1. Make sure, advanced mode is enabled in your user profile (click on your user name to get there)
 2. Navigate to Configuration -> Dashboards -> Resources Tab. Hit (+ ADD RESOURCE) icon
-3. Enter URL `/local/power-distribution-card.js` and select type "JavaScript Module".
-   (Use `/hacsfiles/power-distribution-card/power-distribution-card.js` and select "JavaScript Module" for HACS install if HACS didn't do it already)
+3. Enter URL `/local/power-flow-card.js` and select type "JavaScript Module".
+   (Use `/hacsfiles/power-flow-card/power-flow-card.js` and select "JavaScript Module" for HACS install if HACS didn't do it already)
 
 ## Using the card
 
@@ -50,7 +50,7 @@ I recommend looking at the [Example usage section](#example-usage) to understand
 
 | Name          | Type     |   Default    | Description                                                                                                                             |
 | ------------- | -------- | :----------: | --------------------------------------------------------------------------------------------------------------------------------------- |
-| type          | `string` | **required** | `custom:power-distribution-card`.                                                                                                       |
+| type          | `string` | **required** | `custom:power-flow-card`.                                                                                                               |
 | entities      | `object` | **required** | One or more sensor entities, see [entities object](#entities-object) for additional entity options.                                     |
 | min_flow_rate | `number` |     .75      | Represents the fastest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula). |
 | max_flow_rate | `number` |      6       | Represents the slowest amount of time in seconds for a flow dot to travel from one end to the other, see [flow formula](#flow-formula). |
@@ -78,8 +78,8 @@ Can be use with either Grid or Battery configuration
 #### Using combined entities for grid and battery that support positive state values for consumption and negative state values for production.
 
 ```yaml
-type: custom:power-distribution-card
-title: Realtime Distribution
+type: custom:power-flow-card
+title: Power Distribution
 entities:
   battery: sensor.battery_in_out
   battery_charge: sensor.battery_percent
@@ -91,8 +91,8 @@ max_flow_rate: 10
 #### Using split entities for grid and battery where each consumption and production entity state has a positive value.
 
 ```yaml
-type: custom:power-distribution-card
-title: Realtime Distribution
+type: custom:power-flow-card
+title: Power Distribution
 entities:
   battery:
     consumption: sensor.battery_out

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "power-distribution-card",
+  "name": "Power Flow Card",
   "render_readme": true
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,7 @@ const serveOptions = {
 
 export default [
   {
-    input: "src/power-distribution-card.ts",
+    input: "src/power-flow-card.ts",
     output: [
       {
         dir: "./dist",

--- a/src/power-flow-card-config.ts
+++ b/src/power-flow-card-config.ts
@@ -1,6 +1,6 @@
 import { LovelaceCardConfig } from "custom-card-helpers";
 
-export interface PowerDistributionCardConfig extends LovelaceCardConfig {
+export interface PowerFlowCardConfig extends LovelaceCardConfig {
   entities: {
     battery?:
       | string

--- a/src/power-flow-card.ts
+++ b/src/power-flow-card.ts
@@ -17,17 +17,17 @@ import { formatNumber, HomeAssistant } from "custom-card-helpers";
 import { css, html, LitElement, svg, TemplateResult } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { PowerDistributionCardConfig } from "./power-distribution-card-config.js";
+import { PowerFlowCardConfig } from "./power-flow-card-config.js";
 import { coerceNumber, roundValue } from "./utils.js";
 
 const CIRCLE_CIRCUMFERENCE = 238.76104;
 const MAX_FLOW_RATE = 6;
 const MIN_FLOW_RATE = 0.75;
 
-@customElement("power-distribution-card")
-export class PowerDistributionCard extends LitElement {
+@customElement("power-flow-card")
+export class PowerFlowCard extends LitElement {
   @property({ attribute: false }) public hass!: HomeAssistant;
-  @state() private _config?: PowerDistributionCardConfig;
+  @state() private _config?: PowerFlowCardConfig;
 
   @query("#battery-home-flow") batteryToHomeFlow?: SVGSVGElement;
   @query("#grid-home-flow") gridToHomeFlow?: SVGSVGElement;
@@ -35,7 +35,7 @@ export class PowerDistributionCard extends LitElement {
   @query("#solar-grid-flow") solarToGridFlow?: SVGSVGElement;
   @query("#solar-home-flow") solarToHomeFlow?: SVGSVGElement;
 
-  setConfig(config: PowerDistributionCardConfig): void {
+  setConfig(config: PowerFlowCardConfig): void {
     this._config = {
       ...config,
       min_flow_rate: config.min_flow_rate ?? MIN_FLOW_RATE,
@@ -673,6 +673,6 @@ export class PowerDistributionCard extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "power-distribution-card": PowerDistributionCard;
+    "power-flow-card": PowerFlowCard;
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: card name

card type will need to be changed from `custom:power-distribution-card` to `custom:power-flow-card`

closes #15